### PR TITLE
修复appcan.window.monitorKey 拦截实体按键不起效问题

### DIFF
--- a/source/src/appcan_window.js
+++ b/source/src/appcan_window.js
@@ -27,7 +27,7 @@ window.appcan && appcan.define('window',function($,exports,module){
     */
     function monitorKey(id,callback){
         keyFuncMapper[id] = callback;
-        uexWindow.setReportKey(id);
+        uexWindow.setReportKey(id, 1);
         uexWindow.onKeyPressed = function(keyCode){
             keyFuncMapper[keyCode] && keyFuncMapper[keyCode](keyCode);    
         }


### PR DESCRIPTION
uexWindow.setReportKey(keyCode,enable) 的第二个参数如果不填写，则不会拦截对应按键
